### PR TITLE
fix: SPT-513 - Upgraded NuGet/setup-nuget action to v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ jobs:
 Optional parameters:
 * package-folder:"The folder prefix where the project file is. Defaults to ./"
 * version-suffix: "The version suffix to append to the package version. This value will be ignored if the package Version is specified. Defaults to empty string."
-* version: "The package version. This value will override Version in *.csproj. Defaults to empty string."
+* version: "The package version. This value will override Version in *.csproj. Defaults to empty string." 

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup NuGet.exe
-      uses: NuGet/setup-nuget@v1.0.5
+      uses: NuGet/setup-nuget@v1.1.1
       with:
         nuget-version: 5.9.1
     - name: Auth NuGet


### PR DESCRIPTION
### Upgraded NuGet/setup-nuget action to v1.1.1

The NuGet/setup-nuget v1.0.5 is facing two warnings

- Node.js 12 actions are deprecated.
- The `set-output` command is deprecated and will be disabled soon.

![image](https://user-images.githubusercontent.com/94201128/208661231-3886f3ea-2f44-4e40-9737-f011f1e61621.png)

#### Test
- nuget-pack-push-gh-action action execution with NuGet/setup-nuget v1.0.5 **with warnings** [link](https://github.com/ohpen/oaf-api-dotnet/actions/runs/3739845465/attempts/1)
- nuget-pack-push-gh-action action execution with NuGet/setup-nuget v1.1.1 **without warnings** [link](https://github.com/ohpen/oaf-api-dotnet/actions/runs/3739845465/attempts/4)
